### PR TITLE
fix: remove encoding from password file reads

### DIFF
--- a/vault2vault.py
+++ b/vault2vault.py
@@ -369,7 +369,7 @@ def _load_password(
 
     if fpath:
         try:
-            with Path(fpath).resolve().open("rb", encoding="utf-8") as infile:
+            with Path(fpath).resolve().open("rb") as infile:
                 return VaultSecret(infile.read())
         except (FileNotFoundError, PermissionError) as err:
             raise RuntimeError(


### PR DESCRIPTION
The password files are opened in binary mode so an encoding argument isn't necessary and causes the script to crash.

Fixes #2